### PR TITLE
Table formatting

### DIFF
--- a/embedBuilder.js
+++ b/embedBuilder.js
@@ -4,6 +4,11 @@ const fs = require('fs');
 function emojiMedal(medal) {
 	let emojiString = "";
 	switch(medal) {
+		case 0: // no medal
+			// U+2005 is a midspace, this combination
+			// seems to be about equal to the space of a medal emoji
+			emojiString = '\u2005' + invisibleWhitespaces(2);
+			break;
 		case 1:
 			emojiString = "<:bronze:1259375720749203476>";
 			break;

--- a/embedBuilder.js
+++ b/embedBuilder.js
@@ -34,15 +34,6 @@ function longestNamelength(leaderboard) {
 	});
 	return longestNamelength;
 }
-
-function extraSpaces(name, maxlength) {
-	let diff = maxlength - name.length;
-	// special case because his name uses characters that takes up so little space 
-	// may have to find a way to measure the number of pixels a name takes up
-	//if(name == "Vazyriqx") diff += 2; 
-	return invisibleWhitespaces(diff)
-}
-
 function msToTime(timeMs) {
   let ms = timeMs % 1000;
   timeMs = (timeMs - ms) / 1000;
@@ -70,8 +61,8 @@ function leaderBoardString(leaderboard) {
 	leaderboard.forEach(record => {
 		leaderboardString += (emojiMedal(record.medal) + invisibleWhitespaces(2));
 		leaderboardString += (msToTime(record.time) + invisibleWhitespaces(4));
-		leaderboardString += (capitalizeFirstLetter(record.name) + invisibleWhitespaces(2) + extraSpaces(record.name, maxNamelength));
-		leaderboardString += ('[⭳](' + record.ghostlink + ')' + '\n');
+		leaderboardString += (capitalizeFirstLetter(record.name));
+		leaderboardString += '\r\n';
 	});
 	return leaderboardString;
 }
@@ -113,7 +104,7 @@ function leaderBoardEmbed(leaderboard, map) {
         const table = leaderBoardString(leaderboard);
 		// the u1CBC show up as a box on mobile devices, but i have yet to find another character that isn't just 
 		// stripped at the start of a field, which makes the title not line up with the fields
-        const title = '\u1CBC' + '\u1CBC' + '\u1CBC' + '\u1CBC' + `Time${invisibleWhitespaces(8)}User${invisibleWhitespaces(9)}⭳`;
+        const title = '\u1CBC' + '\u1CBC' + '\u1CBC' + '\u1CBC' + `Time${invisibleWhitespaces(8)}User`;
         embed.addFields({ name: title, value: table });
 		embed.setColor(0xff990a) // orange
     }

--- a/embedBuilder.js
+++ b/embedBuilder.js
@@ -74,7 +74,7 @@ function leaderBoardString(leaderboard) {
 function invisibleWhitespaces(n) {
 	let whitespaceStr = ''
 	for (let index = 0; index < n; index++) {
-		whitespaceStr += '\u1CBC';
+		whitespaceStr += '\u2000';
 	}
 	return whitespaceStr;
 }
@@ -106,7 +106,9 @@ function leaderBoardEmbed(leaderboard, map) {
 		embed.setColor(0xff0000) // error red
     } else {
         const table = leaderBoardString(leaderboard);
-        const title = `${invisibleWhitespaces(4)}Time${invisibleWhitespaces(8)}User${invisibleWhitespaces(9)}⭳`;
+		// the u1CBC show up as a box on mobile devices, but i have yet to find another character that isn't just 
+		// stripped at the start of a field, which makes the title not line up with the fields
+        const title = '\u1CBC' + '\u1CBC' + '\u1CBC' + '\u1CBC' + `Time${invisibleWhitespaces(8)}User${invisibleWhitespaces(9)}⭳`;
         embed.addFields({ name: title, value: table });
 		embed.setColor(0xff990a) // orange
     }

--- a/fetchLeaderBoard.js
+++ b/fetchLeaderBoard.js
@@ -87,7 +87,6 @@ function formatLeaderboard(records) {
         obj.name = getPlayerName(record.accountId);
         obj.medal = record.medal;
         obj.time = record.recordScore.time;
-        obj.ghostlink = record.url;
         leaderboard.push(obj);
     });
 


### PR DESCRIPTION
closes #3  
closes #4 
removes the ghostlink, as this made it look worse on mobile and honestly was never used